### PR TITLE
fix dynamic process.env access

### DIFF
--- a/src/wrapper/Pipedream.ts
+++ b/src/wrapper/Pipedream.ts
@@ -51,8 +51,10 @@ export type PipedreamClientOpts = {
  * @param environment - The Pipedream environment string.
  * @returns The base URL for the Pipedream API.
  */
-const getBaseUrl = (environment: PipedreamEnvironment) =>
-    environment.replace(/\$\{(\w+)\}/g, (_, name) => process.env[name] ?? "");
+const getBaseUrl = (environment: PipedreamEnvironment) => {
+    const replacements = { DEV_NAMESPACE: process.env.DEV_NAMESPACE};
+    environment.replace(/\$\{(\w+)}/g, (_, name: keyof typeof replacements) => replacements[name] ?? "");
+}
 
 export class Pipedream extends PipedreamClient {
     private _workflowDomain?: string;


### PR DESCRIPTION
This change ensures that the ts sdk code is friendlier to website bundlers that need to replace process.env instances.

Ex. in our codebase we get an error when trying to bundle the Pipedream client due to this process.env call:
WARNING in /node_modules/@pipedream/sdk/dist/esm/wrapper/Pipedream.mjs:22:108