### PR TITLE
fix: browser SDK now respects the environment option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+## [2.3.8] - 2026-02-25
+
+### Fixed
+
+- **`environment` option now works in browser bundles.** Previously, `getBaseUrl.browser.ts` was hardcoded to always return `PipedreamEnvironment.Prod` (`https://api.pipedream.com`), ignoring the `environment` argument entirely. This meant that passing `environment: PipedreamEnvironment.Canary` (or any custom environment URL) to `createFrontendClient` had no effect — all browser API requests were silently routed to production regardless.
+
+  `getBaseUrl.browser.ts` now returns the `environment` argument as-is, matching the intent of the Node.js version (minus `${VAR}` placeholder substitution, which requires `process.env` and is not supported in browser contexts).
+
+  **Before (broken):**
+  ```ts
+  // Browser requests always went to api.pipedream.com regardless of this option
+  const client = createFrontendClient({
+    environment: PipedreamEnvironment.Canary,
+    // ...
+  });
+  ```
+
+  **After (fixed):**
+  ```ts
+  // Browser requests now correctly go to api2.pipedream.com
+  const client = createFrontendClient({
+    environment: PipedreamEnvironment.Canary,
+    // ...
+  });
+  ```
+
+  Note: `PipedreamEnvironment.Dev` (which uses a `${DEV_NAMESPACE}` placeholder) is still not supported in the browser, as `process.env` is not available in browser contexts.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pipedream/sdk",
-    "version": "2.3.7",
+    "version": "2.3.8",
     "private": false,
     "repository": "github:PipedreamHQ/pipedream-sdk-typescript",
     "type": "commonjs",

--- a/src/wrapper/utils/getBaseUrl.browser.ts
+++ b/src/wrapper/utils/getBaseUrl.browser.ts
@@ -6,4 +6,4 @@ import { PipedreamEnvironment } from "../../environments.js";
  *
  * @returns The base URL for the Pipedream API.
  */
-export const getBaseUrl = (): string => PipedreamEnvironment.Prod;
+export const getBaseUrl = (environment: string = PipedreamEnvironment.Prod): string => environment;


### PR DESCRIPTION
## Problem

`getBaseUrl.browser.ts` was hardcoded to always return `PipedreamEnvironment.Prod`, ignoring its argument entirely:

```ts
// Before
export const getBaseUrl = (): string => PipedreamEnvironment.Prod;
```

Because the `package.json` `browser` field redirects webpack/bundlers to this file instead of `getBaseUrl.ts`, any browser-bundled app (Next.js, Vite, etc.) would silently route all SDK API requests to `api.pipedream.com` — regardless of what `environment` was passed to `createFrontendClient` or `new PipedreamClient`.

This made it impossible to target non-production environments (e.g. Canary at `api2.pipedream.com`) from browser clients.

## Fix

Return the `environment` argument directly, matching the intent of the Node.js version:

```ts
// After
export const getBaseUrl = (environment: string = PipedreamEnvironment.Prod): string => environment;
```

`PipedreamEnvironment.Dev` (which uses a `${DEV_NAMESPACE}` placeholder) remains unsupported in the browser since `process.env` is not available in browser contexts — same as before.

## Usage

```ts
// Now works correctly in browser bundles
const client = createFrontendClient({
  environment: PipedreamEnvironment.Canary, // → https://api2.pipedream.com
  tokenCallback,
  externalUserId,
});
```

Or via env var in a Next.js app:
```
NEXT_PUBLIC_PIPEDREAM_ENVIRONMENT=https://api2.pipedream.com
```

## Test plan

- [ ] Verify browser requests go to `api2.pipedream.com` when `environment: PipedreamEnvironment.Canary` is passed to `createFrontendClient`
- [ ] Verify browser requests still default to `api.pipedream.com` when no `environment` is specified
- [ ] Verify server-side behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)