### PR TITLE
Add accountId support to browser client connectAccount

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,18 @@
     "private": false,
     "repository": "github:PipedreamHQ/pipedream-sdk-typescript",
     "type": "commonjs",
+    "license": "SEE LICENSE IN LICENSE",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
     "types": "./dist/cjs/index.d.ts",
     "exports": {
         ".": {
             "types": "./dist/cjs/index.d.ts",
+            "browser": {
+                "types": "./dist/esm/browser/index.d.mts",
+                "import": "./dist/esm/browser/index.mjs",
+                "default": "./dist/esm/browser/index.mjs"
+            },
             "import": {
                 "types": "./dist/esm/index.d.mts",
                 "default": "./dist/esm/index.mjs"
@@ -19,6 +25,18 @@
                 "default": "./dist/cjs/index.js"
             },
             "default": "./dist/cjs/index.js"
+        },
+        "./browser": {
+            "types": "./dist/esm/browser/index.d.mts",
+            "import": {
+                "types": "./dist/esm/browser/index.d.mts",
+                "default": "./dist/esm/browser/index.mjs"
+            },
+            "require": {
+                "types": "./dist/cjs/browser/index.d.ts",
+                "default": "./dist/cjs/browser/index.js"
+            },
+            "default": "./dist/esm/browser/index.mjs"
         },
         "./serialization": {
             "types": "./dist/cjs/serialization/index.d.ts",
@@ -31,6 +49,18 @@
                 "default": "./dist/cjs/serialization/index.js"
             },
             "default": "./dist/cjs/serialization/index.js"
+        },
+        "./server": {
+            "types": "./dist/cjs/index.d.ts",
+            "import": {
+                "types": "./dist/esm/index.d.mts",
+                "default": "./dist/esm/index.mjs"
+            },
+            "require": {
+                "types": "./dist/cjs/index.d.ts",
+                "default": "./dist/cjs/index.js"
+            },
+            "default": "./dist/cjs/index.js"
         },
         "./package.json": "./package.json"
     },

--- a/package.json
+++ b/package.json
@@ -1,21 +1,15 @@
 {
     "name": "@pipedream/sdk",
-    "version": "2.4.8",
+    "version": "2.4.9",
     "private": false,
     "repository": "github:PipedreamHQ/pipedream-sdk-typescript",
     "type": "commonjs",
-    "license": "SEE LICENSE IN LICENSE",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.mjs",
     "types": "./dist/cjs/index.d.ts",
     "exports": {
         ".": {
             "types": "./dist/cjs/index.d.ts",
-            "browser": {
-                "types": "./dist/esm/browser/index.d.mts",
-                "import": "./dist/esm/browser/index.mjs",
-                "default": "./dist/esm/browser/index.mjs"
-            },
             "import": {
                 "types": "./dist/esm/index.d.mts",
                 "default": "./dist/esm/index.mjs"
@@ -25,18 +19,6 @@
                 "default": "./dist/cjs/index.js"
             },
             "default": "./dist/cjs/index.js"
-        },
-        "./browser": {
-            "types": "./dist/esm/browser/index.d.mts",
-            "import": {
-                "types": "./dist/esm/browser/index.d.mts",
-                "default": "./dist/esm/browser/index.mjs"
-            },
-            "require": {
-                "types": "./dist/cjs/browser/index.d.ts",
-                "default": "./dist/cjs/browser/index.js"
-            },
-            "default": "./dist/esm/browser/index.mjs"
         },
         "./serialization": {
             "types": "./dist/cjs/serialization/index.d.ts",
@@ -49,18 +31,6 @@
                 "default": "./dist/cjs/serialization/index.js"
             },
             "default": "./dist/cjs/serialization/index.js"
-        },
-        "./server": {
-            "types": "./dist/cjs/index.d.ts",
-            "import": {
-                "types": "./dist/esm/index.d.mts",
-                "default": "./dist/esm/index.mjs"
-            },
-            "require": {
-                "types": "./dist/cjs/index.d.ts",
-                "default": "./dist/cjs/index.js"
-            },
-            "default": "./dist/cjs/index.js"
         },
         "./package.json": "./package.json"
     },

--- a/src/api/resources/accounts/client/requests/CreateAccountOpts.ts
+++ b/src/api/resources/accounts/client/requests/CreateAccountOpts.ts
@@ -22,4 +22,6 @@ export interface CreateAccountOpts {
     connectToken: string;
     /** Optional name for the account */
     name?: string;
+    /** An existing account ID to reconnect. When provided, the account's credentials are updated instead of creating a new account. Must belong to the same external user and project environment as the connect token, and match the app identified by app_slug. */
+    accountId?: string;
 }

--- a/src/api/resources/tokens/client/Client.ts
+++ b/src/api/resources/tokens/client/Client.ts
@@ -132,6 +132,7 @@ export class Tokens {
      * @example
      *     await client.tokens.validate("ctok", {
      *         appId: "app_id",
+     *         accountId: "account_id",
      *         oauthAppId: "oauth_app_id"
      *     })
      */
@@ -148,9 +149,13 @@ export class Tokens {
         request: Pipedream.TokensValidateRequest,
         requestOptions?: Tokens.RequestOptions,
     ): Promise<core.WithRawResponse<Pipedream.ValidateTokenResponse>> {
-        const { appId, oauthAppId } = request;
+        const { appId, accountId, oauthAppId } = request;
         const _queryParams: Record<string, string | string[] | object | object[] | null> = {};
         _queryParams.app_id = appId;
+        if (accountId != null) {
+            _queryParams.account_id = accountId;
+        }
+
         if (oauthAppId != null) {
             _queryParams.oauth_app_id = oauthAppId;
         }

--- a/src/api/resources/tokens/client/requests/TokensValidateRequest.ts
+++ b/src/api/resources/tokens/client/requests/TokensValidateRequest.ts
@@ -4,12 +4,15 @@
  * @example
  *     {
  *         appId: "app_id",
+ *         accountId: "account_id",
  *         oauthAppId: "oauth_app_id"
  *     }
  */
 export interface TokensValidateRequest {
     /** The app ID to validate against */
     appId: string;
+    /** An existing account ID to reconnect. Must belong to the app identified by app_id. */
+    accountId?: string;
     /** The OAuth app ID to validate against (if the token is for an OAuth app) */
     oauthAppId?: string;
 }

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -95,6 +95,12 @@ export type StartConnectOpts = {
     oauthAppId?: App["id"];
 
     /**
+     * An existing account ID to reconnect. When provided, the account's
+     * credentials are updated instead of creating a new account.
+     */
+    accountId?: string;
+
+    /**
      * Callback function to be called upon successful connection.
      *
      * @param res - The result of the connection.
@@ -310,6 +316,10 @@ export class PipedreamClient extends BackendClient {
 
         if (opts.oauthAppId) {
             qp.set("oauthAppId", opts.oauthAppId);
+        }
+
+        if (opts.accountId) {
+            qp.set("accountId", opts.accountId);
         }
 
         if (opts.hideClose) {

--- a/src/serialization/resources/accounts/client/requests/CreateAccountOpts.ts
+++ b/src/serialization/resources/accounts/client/requests/CreateAccountOpts.ts
@@ -12,6 +12,7 @@ export const CreateAccountOpts: core.serialization.Schema<
     cfmapJson: core.serialization.property("cfmap_json", core.serialization.string()),
     connectToken: core.serialization.property("connect_token", core.serialization.string()),
     name: core.serialization.string().optional(),
+    accountId: core.serialization.property("account_id", core.serialization.string().optional()),
 });
 
 export declare namespace CreateAccountOpts {
@@ -20,5 +21,6 @@ export declare namespace CreateAccountOpts {
         cfmap_json: string;
         connect_token: string;
         name?: string | null;
+        account_id?: string | null;
     }
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const SDK_VERSION = "2.4.8";
+export const SDK_VERSION = "2.4.9";


### PR DESCRIPTION
Adds optional accountId parameter to StartConnectOpts for reconnecting existing accounts. When provided, the Connect UI will update the account's credentials instead of creating a new account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `accountId` parameter support across account creation and token validation operations.

* **Chores**
  * Updated SDK version from 2.4.8 to 2.4.9.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PipedreamHQ/pipedream-sdk-typescript/pull/345?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->