### PR TITLE
Add accountId support to browser client connectAccount

### DIFF
--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -95,6 +95,12 @@ export type StartConnectOpts = {
     oauthAppId?: App["id"];
 
     /**
+     * An existing account ID to reconnect. When provided, the account's
+     * credentials are updated instead of creating a new account.
+     */
+    accountId?: string;
+
+    /**
      * Callback function to be called upon successful connection.
      *
      * @param res - The result of the connection.
@@ -310,6 +316,10 @@ export class PipedreamClient extends BackendClient {
 
         if (opts.oauthAppId) {
             qp.set("oauthAppId", opts.oauthAppId);
+        }
+
+        if (opts.accountId) {
+            qp.set("accountId", opts.accountId);
         }
 
         if (opts.hideClose) {


### PR DESCRIPTION
Adds optional accountId parameter to StartConnectOpts for reconnecting existing accounts. When provided, the Connect UI will update the account's credentials instead of creating a new account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added support for reconnecting to existing accounts and updating credentials without creating new accounts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PipedreamHQ/pipedream-sdk-typescript/pull/346?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->