### PR TITLE
feat: forward headers option from PipedreamClientOpts to base client

### DIFF
--- a/src/wrapper/Pipedream.ts
+++ b/src/wrapper/Pipedream.ts
@@ -1,5 +1,4 @@
 import type { TokenProvider } from "../core/auth/TokenProvider.js";
-import type { Supplier } from "../core/fetcher/Supplier.js";
 import { ProjectEnvironment } from "../api/index.js";
 import { WorkflowsClient } from "../api/resources/workflows/client/Client.js";
 import { PipedreamClient } from "../Client.js";
@@ -41,7 +40,7 @@ export type PipedreamClientOpts = {
     /**
      * Additional headers to include in every request.
      */
-    headers?: Record<string, string | Supplier<string | null | undefined> | null | undefined>;
+    headers?: PipedreamClient.Options['headers'];
 
     /**
      * Optional custom domain for workflow execution.

--- a/src/wrapper/Pipedream.ts
+++ b/src/wrapper/Pipedream.ts
@@ -1,4 +1,5 @@
 import type { TokenProvider } from "../core/auth/TokenProvider.js";
+import type { Supplier } from "../core/fetcher/Supplier.js";
 import { ProjectEnvironment } from "../api/index.js";
 import { WorkflowsClient } from "../api/resources/workflows/client/Client.js";
 import { PipedreamClient } from "../Client.js";
@@ -38,6 +39,11 @@ export type PipedreamClientOpts = {
     tokenProvider?: TokenProvider;
 
     /**
+     * Additional headers to include in every request.
+     */
+    headers?: Record<string, string | Supplier<string | null | undefined> | null | undefined>;
+
+    /**
      * Optional custom domain for workflow execution.
      */
     workflowDomain?: string;
@@ -68,6 +74,7 @@ export class Pipedream extends PipedreamClient {
             baseUrl: opts.baseUrl ?? process.env.PIPEDREAM_BASE_URL ?? PipedreamEnvironment.Prod,
             projectEnvironment,
             projectId: projectId ?? "",
+            headers: opts.headers,
         };
 
         if ("tokenProvider" in opts) {


### PR DESCRIPTION
Exposes the base client's `headers` option through `PipedreamClientOpts`, allowing callers to set per-client default headers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for supplying custom headers with requests. Headers provided in configuration are included with every API call.
  * Headers may be static or dynamically provided at configuration time, enabling custom authentication, tracing, or other per-request metadata to be consistently applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->